### PR TITLE
Add an authentication helper

### DIFF
--- a/spec/integration/fetch_status_spec.rb
+++ b/spec/integration/fetch_status_spec.rb
@@ -11,15 +11,7 @@ RSpec.feature 'Fetching the status' do
 
   scenario 'returns the database status from the allocation api' do
     start_page = ENV.fetch('START_PAGE') + '/status'
-
-    visit start_page
-
-    expect(page).to have_content('Username')
-    expect(page).to have_content('Password')
-
-    fill_in 'Username', with: ENV.fetch('STAFF_USERNAME')
-    fill_in 'Password', with: ENV.fetch('STAFF_PASSWORD')
-    click_button('Sign in')
+    sign_in_and_go(start_page)
 
     expect(page).to have_css('.status', text: 'ok')
     expect(page).to have_css('.postgres_version', text: 'PostgreSQL 10.5')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,11 +5,15 @@ Bundler.setup(:default, :development)
 require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
 
+Dir["./spec/support/**/*.rb"].each {|f| require f}
+
 Capybara.default_driver = :selenium
 Capybara.save_path = File.expand_path('../screenshots', __dir__)
 Capybara.default_max_wait_time = 10
 
 RSpec.configure do |config|
+  config.include Helpers::Authentication, type: :feature
+
   config.disable_monkey_patching!
   config.before(:all) do
     page.driver.browser.manage.window.resize_to(1920, 1080)

--- a/spec/support/helpers/authentication.rb
+++ b/spec/support/helpers/authentication.rb
@@ -1,0 +1,15 @@
+module Helpers
+    module Authentication
+      def sign_in_and_go(url)
+        visit url
+
+        expect(page).to have_content('Username')
+        expect(page).to have_content('Password')
+
+        fill_in 'Username', with: ENV.fetch('STAFF_USERNAME')
+        fill_in 'Password', with: ENV.fetch('STAFF_PASSWORD')
+
+        click_button('Sign in')
+      end
+    end
+  end


### PR DESCRIPTION
Adds an authentication helper to make it easier to use so that instead
of going through the login, now you can call sign_in_and_go and it will
log in the user for the scenario and then go to the specified page.