### PR TITLE
Integration test for editing POMs

### DIFF
--- a/spec/integration/fetch_status_spec.rb
+++ b/spec/integration/fetch_status_spec.rb
@@ -3,17 +3,15 @@ require 'spec_helper'
 RSpec.feature 'Fetching the status' do
   scenario 'returns a status message from the health endpoint' do
     start_page = ENV.fetch('START_PAGE') + '/health'
-
     visit start_page
 
     expect(page).to have_content('Everything is fine.')
   end
 
   scenario 'returns the database status from the allocation api' do
-    start_page = ENV.fetch('START_PAGE') + '/status'
-    sign_in_and_go(start_page)
+    sign_in_and_go(ENV.fetch('START_PAGE') + '/status')
 
     expect(page).to have_css('.status', text: 'ok')
-    expect(page).to have_css('.postgres_version', text: 'PostgreSQL 10.5')
+    expect(page).to have_css('.postgres_version', text: 'PostgreSQL')
   end
 end

--- a/spec/integration/manage_pom_spec.rb
+++ b/spec/integration/manage_pom_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.feature 'POM management' do
+  scenario 'editing a POMs' do
+    sign_in_and_go ENV.fetch('START_PAGE')
+    expect(page).to have_content('Dashboard')
+
+    click_on("Active POMs")
+    expect_breadcrumbs(2)
+    expect(page).to have_content('Prison Offender Managers')
+    expect(page).to have_css('.govuk-tabs__list-item', count: 2)
+
+    page.first(:link, "View").click
+    expect_breadcrumbs(3)
+    expect(page).to have_content('POM level')
+    expect(page).to have_content('Working pattern')
+
+    find('.govuk-button').click
+    expect_backlink
+    expect(page).to have_content('Edit profile')
+
+    # The actual radio buttons we want here aren't visible because of how the
+    # design scheme works.
+    find('#working-pattern-1', :visible => false).choose
+    find('#working-status-1', :visible => false).choose
+    click_button('Save')
+
+    expect(page).to have_content('Routing Error')
+  end
+end

--- a/spec/integration/manage_pom_spec.rb
+++ b/spec/integration/manage_pom_spec.rb
@@ -24,7 +24,5 @@ RSpec.feature 'POM management' do
     find('#working-pattern-1', :visible => false).choose
     find('#working-status-1', :visible => false).choose
     click_button('Save')
-
-    expect(page).to have_content('Routing Error')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ Capybara.default_max_wait_time = 10
 
 RSpec.configure do |config|
   config.include Helpers::Authentication, type: :feature
+  config.include Helpers::Breadcrumbs, type: :feature
 
   config.disable_monkey_patching!
   config.before(:all) do

--- a/spec/support/helpers/authentication.rb
+++ b/spec/support/helpers/authentication.rb
@@ -2,6 +2,7 @@ module Helpers
     module Authentication
       def sign_in_and_go(url)
         visit url
+        return if page.has_link?('Sign out')
 
         expect(page).to have_content('Username')
         expect(page).to have_content('Password')
@@ -10,6 +11,10 @@ module Helpers
         fill_in 'Password', with: ENV.fetch('STAFF_PASSWORD')
 
         click_button('Sign in')
+      end
+
+      def signout()
+        click_on('Sign out')
       end
     end
   end

--- a/spec/support/helpers/authentication.rb
+++ b/spec/support/helpers/authentication.rb
@@ -12,9 +12,5 @@ module Helpers
 
         click_button('Sign in')
       end
-
-      def signout()
-        click_on('Sign out')
-      end
     end
   end

--- a/spec/support/helpers/breadcrumbs.rb
+++ b/spec/support/helpers/breadcrumbs.rb
@@ -1,0 +1,11 @@
+module Helpers
+    module Breadcrumbs
+      def expect_breadcrumbs(count)
+        expect(page).to have_css('.govuk-breadcrumbs__link', count: count)
+      end
+
+      def expect_backlink()
+        expect(page).to have_css('.govuk-back-link', count: 1)
+      end
+    end
+  end


### PR DESCRIPTION
Adds a new integration test for editing a POM, although it is currently
only MVP and will fail on the final save.

To make sure that multiple integration tests don't causes issues with
login state (and as they are unordered) the sign_in_and_go function can
be used multiple times as it will return early if the user is already
signed in (after navigating to the link).  Unfortunately this
dramatically slows down the SSO sign in as by default Capybara find()
calls wait for a period of time for the element to appear.  If we don't
use a lot of JS for the display of elements on the page we can reduce
the max_wait_time to speed up the tests.

Also adds a breadcrumb helper so we can check on each page that it shows
the correct number of breadcrumbs, or includes a backlink.