### PR TITLE
Update spec to match new route

### DIFF
--- a/spec/integration/create_allocation_spec.rb
+++ b/spec/integration/create_allocation_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Allocation' do
     find('#case_information_tier_A', visible: false).choose
     click_button 'Save'
 
-    visit "#{ENV.fetch('START_PAGE')}/allocations#awaiting-allocation"
+    visit "#{ENV.fetch('START_PAGE')}/summary#awaiting-allocation"
     within('.offender_row_0') do
       click_link 'Allocate'
     end
@@ -26,6 +26,6 @@ RSpec.feature 'Allocation' do
 
     click_button 'Complete allocation'
 
-    expect(page).to have_current_path "#{ENV.fetch('START_PAGE')}/allocations#awaiting-allocation"
+    expect(page).to have_current_path "#{ENV.fetch('START_PAGE')}/summary#awaiting-allocation"
   end
 end


### PR DESCRIPTION
We have recently changed the name of the allocations controller to
summary instead, which has caused the integration tests to start
failing.  This PR updates the specs to use the new/correct path.