### PR TITLE
Add time for save to complete

### DIFF
--- a/spec/integration/create_allocation_spec.rb
+++ b/spec/integration/create_allocation_spec.rb
@@ -17,6 +17,8 @@ RSpec.feature 'Allocation' do
 
     click_button 'Save'
 
+    sleep 5
+
     visit "#{ENV.fetch('START_PAGE')}/summary#awaiting-allocation"
     within('.offender_row_0') do
       click_link 'Allocate'


### PR DESCRIPTION
When creating an allocation there is a delay of a few seconds whilst the
record is saving to the database.  As such this is causing the test to
fail as it's trying to move onto the next step to quickly.  I have added
a 5 second sleep to allow the record to save so the test can move on
successfully.