### PR TITLE
Only execute integration tests via Cron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             wget https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz
             tar -zxvf geckodriver-v0.23.0-linux64.tar.gz
             sudo mv geckodriver /usr/local/bin/
-      - run: bundle exec rspec spec --no-color --format documentation --format RspecJunitFormatter -o screenshots/rspec.xml
+      - run: bundle exec rspec spec/integration --no-color --format documentation --format RspecJunitFormatter -o screenshots/rspec.xml
       - save_cache:
           key: bundler-{{ checksum "Gemfile.lock" }}
           paths:


### PR DESCRIPTION
Only run the integration tests on a cron job until we figure out how to go about executing Smoke tests on production. Production maintains a whitelist and CircleCI cannot currently access this.