### PR TITLE
Remove Caseload page checks from smoke tests

### DIFF
--- a/spec/smoke/smoke_spec.rb
+++ b/spec/smoke/smoke_spec.rb
@@ -20,18 +20,8 @@ RSpec.feature 'Smoke test' do
 
     expect(page).to have_css('.govuk-breadcrumbs__link', text: 'Update information')
 
-    visit root + "/caseload"
-
-    expect(page).to have_css('.govuk-breadcrumbs__link', text: 'Your caseload')
-
-    visit root + "/caseload/new"
-
-    expect(page).to have_css('.govuk-breadcrumbs__link', text: 'New cases')
-
     visit root + "/poms"
 
     expect(page).to have_css('.govuk-breadcrumbs__link', text: 'Prison Offender Managers')
   end
 end
-
-


### PR DESCRIPTION
We currently have smoke tests that run against production and check that
all the pages can be visited.  However, a while ago the dashboard view
was amended so only POMs can see the 'Your Caseload' / 'New Cases'
section.  As none of us can be POMs in prod NOMIS (as we'll show up in
real prisons which would cause issues) we need to remove this part of
the check as we can't actually visit these pages.