### PR TITLE
Update integration tests so they pass

### DIFF
--- a/spec/integration/create_allocation_spec.rb
+++ b/spec/integration/create_allocation_spec.rb
@@ -6,21 +6,19 @@ RSpec.feature 'Allocation' do
   scenario 'create an allocation' do
     sign_in_and_go_staging ENV.fetch('STAGING_START_PAGE')
 
-    # Temporarily disabled whilst case info undergoes changes
+    click_link 'Update case information'
 
-    # click_link 'Update case information'
+    within('.offender_row_0') do
+      click_link 'Edit'
+    end
 
-    # within('.offender_row_0') do
-    #   click_link 'Update'
-    # end
+    find("#case_information_omicable_Yes", visible: false).choose
 
-    # find("#case_information_omicable_Yes", visible: false).choose
+    tiers = %w[a b c d]
+    fill_in_case_information(tiers.sample)
 
-    # tiers = %w[a b c d]
-    # fill_in_case_information(tiers.sample)
-
-    # click_button 'Save'
-    # expect(page).to have_content('Update information')
+    click_button 'Save'
+    expect(page).to have_content('Update information')
 
     visit "#{ENV.fetch('STAGING_START_PAGE')}/prisons/LEI/summary/unallocated"
     expect(page).to have_content('Make allocations')


### PR DESCRIPTION
We temporarily disabled the integration tests to update the case
information section during the 'create allocation' spec due to changes
being made to the case info page.  However, this work has been done and
now the tests are failing as there aren't any cases ready for
allocation.  This tiny PR enables the updating of case info again so we
can get the tests passing again.