### PR TITLE
Update allocation spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.6.3'
 
 gem 'capybara'
 gem 'capybara-screenshot'
-# gem 'excon'
+gem 'geckodriver-helper'
 gem 'rspec'
 gem 'rspec_junit_formatter'
 gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,8 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    archive-zip (0.12.0)
+      io-like (~> 0.3.0)
     byebug (11.0.1)
     capybara (3.29.0)
       addressable
@@ -18,6 +20,9 @@ GEM
     childprocess (2.0.0)
       rake (< 13.0)
     diff-lcs (1.3)
+    geckodriver-helper (0.24.0)
+      archive-zip (~> 0.7)
+    io-like (0.3.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     mini_mime (1.0.2)
@@ -59,6 +64,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot
+  geckodriver-helper
   rspec
   rspec_junit_formatter
   selenium-webdriver

--- a/spec/integration/create_allocation_spec.rb
+++ b/spec/integration/create_allocation_spec.rb
@@ -38,8 +38,8 @@ RSpec.feature 'Allocation' do
     # Explicitly wait for the following page to load, it's a slow one so we can't
     # assume the page URL has already changed.
     sleep 30
-
-    expect(page).to have_current_path "#{ENV.fetch('STAGING_START_PAGE')}/prisons/LEI/summary/unallocated"
+    
+    expect(page).to have_current_path "#{ENV.fetch('STAGING_START_PAGE')}/prisons/LEI/summary/unallocated?page=1&sort="
   end
 
   def fill_in_case_information(tier)


### PR DESCRIPTION
A change to the codebase from this PR
(https://github.com/ministryofjustice/offender-management-allocation-manager/pull/812)
means that the create_allocation_spec started failing, this PR updates
the expected page path following allocation to ensure it now passes.

In addition we are now making use of geckodriver and we need to add the
geckodriver-helper gem in order for these integration tests to run
locally.