### PR TITLE
Reconfigure CircleCI to use new `main` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - test

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
-START_PAGE=http://example.com
-STAFF_USERNAME='string'
-STAFF_PASSWORD='string'
+# Staging details for integration specs
+STAGING_START_PAGE=https://example.com
+STAGING_STAFF_USERNAME=example
+STAGING_STAFF_PASSWORD=password
+
+# Production details for smoke tests
+PRODUCTION_START_PAGE=https://example.com
+PRODUCTION_STAFF_USERNAME=example
+PRODUCTION_STAFF_PASSWORD=password


### PR DESCRIPTION
This PR reconfigures CircleCI to use the new `main` branch instead of `master`.

Once merged, I'll be able to remove the `master` branch as it'll no longer be needed.