### PR TITLE
remove expect_breadcrumbs lines as they are no longer there

### DIFF
--- a/spec/integration/create_allocation_spec.rb
+++ b/spec/integration/create_allocation_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Allocation' do
     fill_in_case_information(tiers.sample)
 
     click_button 'Save'
-    expect(page).to have_content('Update information')
+    expect(page).to have_content('Add missing information')
 
     visit "#{ENV.fetch('STAGING_START_PAGE')}/prisons/LEI/summary/unallocated"
     expect(page).to have_content('Make allocations')

--- a/spec/integration/manage_pom_spec.rb
+++ b/spec/integration/manage_pom_spec.rb
@@ -8,12 +8,10 @@ RSpec.feature 'POM management' do
     expect(page).to have_content('Dashboard')
 
     click_on('View all offender managers')
-    expect_breadcrumbs(2)
     expect(page).to have_content('Prison Offender Managers')
     expect(page).to have_css('.govuk-tabs__list-item', count: 2)
 
     page.first(:link, 'View').click
-    expect_breadcrumbs(3)
     expect(page).to have_content('POM level')
     expect(page).to have_content('Working pattern')
 


### PR DESCRIPTION
With the new navigation structures, none of the old 'breadcrumbs' are present - hence the integration test  fail.
This PR removes those checks as they no longer make sense