### PR TITLE
Stablise flakey test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   test:
     parallelism: 1
     working_directory: ~/offender-management-integration-tests
+    resource_class: small
     docker:
       - image: circleci/ruby:2.6.6-node-browsers
     steps:
@@ -38,10 +39,10 @@ workflows:
   commit:
     jobs:
       - test
-  hourly:
+  threehourly:
     triggers:
       - schedule:
-          cron: 0 * * * *
+          cron: 30 0,3,6,9,12,15,18,21 * * *
           filters:
             branches:
               only:

--- a/spec/integration/create_allocation_spec.rb
+++ b/spec/integration/create_allocation_spec.rb
@@ -8,6 +8,9 @@ RSpec.feature 'Allocation' do
 
     click_link 'Update case information'
 
+    wait_for { current_path.include?('pending') }
+
+    find('.offender_row_0')
     within('.offender_row_0') do
       click_link 'Edit'
     end
@@ -37,7 +40,8 @@ RSpec.feature 'Allocation' do
 
     # Explicitly wait for the following page to load, it's a slow one so we can't
     # assume the page URL has already changed.
-    sleep 30
+    wait_for { current_path.include?('unallocated') }
+
     expect(page).to have_content('Make allocations')
   end
 

--- a/spec/support/helpers/breadcrumbs.rb
+++ b/spec/support/helpers/breadcrumbs.rb
@@ -9,5 +9,9 @@ module Helpers
     def expect_backlink
       expect(page).to have_css('.govuk-back-link', count: 1)
     end
+
+    def wait_for(maximum_wait_in_seconds = 10)
+      Selenium::WebDriver::Wait.new(timeout: maximum_wait_in_seconds).until { yield }
+    end
   end
 end


### PR DESCRIPTION
The intgration tests fail arbitrarily sometimes (often at night) if the performance of the Prison API is a little off.
This PR tries to fix it by by adding a find before the click of the 'Edit' button 