### PR TITLE
Bug fix: update a URL which has changed in MPC

### DIFF
--- a/spec/integration/create_allocation_spec.rb
+++ b/spec/integration/create_allocation_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Allocation' do
 
     click_link 'Update case information'
 
-    wait_for { current_path.include?('pending') }
+    wait_for { current_path.include?('missing_information') }
 
     find('.offender_row_0')
     within('.offender_row_0') do


### PR DESCRIPTION
The 'Add missing information' screen is now available at `/missing_information` rather than `/pending`