### PR TITLE
Update the 'Allocate' link with the offender's name

### DIFF
--- a/spec/integration/create_allocation_spec.rb
+++ b/spec/integration/create_allocation_spec.rb
@@ -27,7 +27,9 @@ RSpec.feature 'Allocation' do
     expect(page).to have_content('Make allocations')
 
     within('.offender_row_0') do
-      click_link 'Allocate'
+      within('td[aria-label="Prisoner name"]') do
+        find('a').click
+      end
     end
 
     wait_for(30) { page.has_content? 'Allocate a POM' }


### PR DESCRIPTION
This PR fixes the integration tests that broke as a result of MO-510 where the allocate action was removed and the prisoners name was replaced as a link. 