### PR TITLE
Update allocation journey to expect new content

### DIFF
--- a/spec/integration/create_allocation_spec.rb
+++ b/spec/integration/create_allocation_spec.rb
@@ -6,13 +6,13 @@ RSpec.feature 'Allocation' do
   scenario 'create an allocation' do
     sign_in_and_go_staging ENV.fetch('STAGING_START_PAGE')
 
-    click_link 'Update case information'
+    expect(page).to have_heading('Dashboard')
+    click_link 'Add missing details'
 
-    wait_for { current_path.include?('missing_information') }
+    expect(page).to have_heading('Add missing details')
 
-    find('.offender_row_0')
     within('.offender_row_0') do
-      click_link 'Edit'
+      click_link 'Add missing details'
     end
 
     select_welshness('Yes')
@@ -21,10 +21,10 @@ RSpec.feature 'Allocation' do
     fill_in_case_information(tiers.sample)
 
     click_button 'Save'
-    expect(page).to have_content('Add missing information')
+    expect(page).to have_heading('Add missing details')
 
-    click_link 'Make allocations'
-    expect(page).to have_content('Make allocations')
+    click_link 'Make new allocations'
+    expect(page).to have_heading('Make new allocations')
 
     within('.offender_row_0') do
       within('td[aria-label="Prisoner name"]') do
@@ -32,7 +32,7 @@ RSpec.feature 'Allocation' do
       end
     end
 
-    wait_for(30) { page.has_content? 'Allocate a POM' }
+    expect(page).to have_heading('Allocate a POM')
 
     pom_rows = %w[1 2 3]
 
@@ -48,7 +48,12 @@ RSpec.feature 'Allocation' do
     # assume the page URL has already changed.
     wait_for { current_path.include?('unallocated') }
 
-    expect(page).to have_content('Make allocations')
+    expect(page).to have_heading('Make new allocations')
+
+    within('.notification') do
+      # Expect to see flash message "{Offender Name} has been allocated to {POM name}"
+      expect(page).to have_content 'has been allocated'
+    end
   end
 
   def fill_in_case_information(tier)

--- a/spec/integration/manage_pom_spec.rb
+++ b/spec/integration/manage_pom_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.feature 'POM management' do
   scenario 'editing a POMs' do
     sign_in_and_go_staging ENV.fetch('STAGING_START_PAGE')
-    expect(page).to have_content('Dashboard')
+    expect(page).to have_heading('Dashboard')
 
     click_on('View all offender managers')
     wait_for { page.has_content? 'Manage your staff' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,9 @@ Dir['./spec/support/**/*.rb'].each { |f| require f }
 
 Capybara.default_driver = :selenium
 Capybara.save_path = File.expand_path('../screenshots', __dir__)
-Capybara.default_max_wait_time = 10
+
+# Wait (up to) a really long time for pages to load – useful for when the Prison API is being slow
+Capybara.default_max_wait_time = 30
 
 RSpec.configure do |config|
   config.include Helpers::Authentication, type: :feature

--- a/spec/support/helpers/authentication.rb
+++ b/spec/support/helpers/authentication.rb
@@ -5,15 +5,20 @@ module Helpers
   module Authentication
     def sign_in_and_go_staging(url)
       visit url
-      return if page.has_link?('Sign out')
 
-      expect(page).to have_content('Username')
-      expect(page).to have_content('Password')
+      if page.has_content?('Sign in', wait: 5)
+        # We've been redirected to HMPPS Auth. We need to sign in.
+        expect(page).to have_content('Username')
+        expect(page).to have_content('Password')
 
-      fill_in 'Username', with: ENV.fetch('STAGING_STAFF_USERNAME')
-      fill_in 'Password', with: ENV.fetch('STAGING_STAFF_PASSWORD')
+        fill_in 'Username', with: ENV.fetch('STAGING_STAFF_USERNAME')
+        fill_in 'Password', with: ENV.fetch('STAGING_STAFF_PASSWORD')
 
-      click_button('Sign in')
+        click_button('Sign in')
+      else
+        # Otherwise, expect to see a "Sign out" link on the page.
+        expect(page).to have_link('Sign out')
+      end
     end
 
     def sign_in_and_go_production(url)

--- a/spec/support/helpers/matchers.rb
+++ b/spec/support/helpers/matchers.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :have_heading do |heading_text|
+  match do |actual|
+    actual.has_css?('h1', text: heading_text)
+  end
+end


### PR DESCRIPTION
Page titles and link text has changed on the allocation journey, which was causing these integration tests to fail.

This commit updates them to follow the new journey.