### PR TITLE
Update CircleCI config and Bundler version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,41 +1,48 @@
-version: 2
+version: 2.1
+orbs:
+  browser-tools: circleci/browser-tools@1.1.3
 jobs:
   test:
     parallelism: 1
-    working_directory: ~/offender-management-integration-tests
     resource_class: small
     docker:
-      - image: circleci/ruby:2.6.6-node-browsers
+      - image: cimg/ruby:2.6.6-browsers
     steps:
       - checkout
       - restore_cache:
-          key: bundler-{{ checksum "Gemfile.lock" }}
-      - run: bundle check --path vendor/bundle || bundle install --path vendor/bundle
+          key: integration-tests-{{ checksum "Gemfile.lock" }}-v1 # increment v number to bust cache
       - run:
-          name: install firefox
-          command: |
-            wget -L "https://ftp.mozilla.org/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2" -O "firefox-$FIREFOX_VERSION.tar.bz2"
-            tar xjf "firefox-$FIREFOX_VERSION.tar.bz2"
-            sudo rm -rf /opt/firefox
-            sudo mv firefox /opt/
-            sudo ln -sf /opt/firefox/firefox /usr/bin/firefox
+          name: Ensure local bin directory exists
+          command: mkdir -p ~/.local/bin
       - run:
-          name: install geckodriver
+          # Firefox needs to be available from /usr/local/bin or else the Orb will re-install it
+          name: Restore Firefox installation from cache (if in cache)
           command: |
-            wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz
-            tar -zxvf geckodriver-v0.24.0-linux64.tar.gz
-            sudo mv geckodriver /usr/local/bin/
-      - run: bundle exec rspec spec/integration --no-color --format documentation --format RspecJunitFormatter -o screenshots/rspec.xml
+            if [ -e ~/.local/bin/firefox ]
+            then
+              sudo cp -P ~/.local/bin/firefox /usr/local/bin/firefox
+            fi
+      - browser-tools/install-firefox:
+          install-dir: /home/circleci/.local/bin
+      - run:
+          # Copy the Firefox symlink back into ~/.local/bin so it persists to the cache
+          name: Put Firefox installation into the local bin directory
+          command: cp -P /usr/local/bin/firefox ~/.local/bin/firefox
+      - browser-tools/install-geckodriver:
+          install-dir: /home/circleci/.local/bin
+      - run: bundle config set path 'vendor/bundle'
+      - run: bundle check || bundle install
       - save_cache:
-          key: bundler-{{ checksum "Gemfile.lock" }}
+          key: integration-tests-{{ checksum "Gemfile.lock" }}-v1 # increment v number to bust cache
           paths:
             - vendor/bundle
+            - ~/.local/bin
+      - run: bundle exec rspec spec/integration --format documentation --format RspecJunitFormatter -o screenshots/rspec.xml
       - store_test_results:
           path: screenshots
       - store_artifacts:
           path: screenshots
 workflows:
-  version: 2
   commit:
     jobs:
       - test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,4 +67,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   1.17.2
+   2.2.11


### PR DESCRIPTION
### Update Bundler

We were still using Bundler 1.x which was superseded by Bundler 2.x about 2 years ago.

Problems started cropping up in CircleCI when switching to their 'new' Ruby images (away from their 'legacy') ones. A 1.x version of Bundler isn't installed on these new images. However rather than installing the old version, it makes sense just to upgrade Bundler.

### Update CircleCI config

As a knock-on effect of the CircleCI updates in the main repo ministryofjustice/offender-management-allocation-manager, the same updates are needed to the CircleCI config here.